### PR TITLE
Add heuristic matching engine and API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.env
+.venv
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,93 @@
 # Hirex
+
+A lightweight matching platform that uses a heuristic AI engine to connect candidate profiles to job postings. The project ships with a FastAPI service and a reusable Python matching engine that can be embedded in other backends or automated workflows.
+
+## Features
+
+- Weighted scoring engine that considers skills, experience, salary expectations, location preferences, and industry fit.
+- FastAPI service exposing a `/match` endpoint to request recommendations for multiple candidates at once.
+- Configurable weights per request to emphasise specific hiring priorities.
+- Comprehensive unit tests covering the core scoring logic.
+
+## Getting Started
+
+### 1. Install dependencies
+
+Create a virtual environment (recommended) and install project requirements:
+
+```bash
+pip install -r requirements.txt
+```
+
+### 2. Run the API locally
+
+```bash
+uvicorn app.main:app --reload
+```
+
+Once the server is running you can explore the automatically generated docs at [http://localhost:8000/docs](http://localhost:8000/docs).
+
+### 3. Request matches
+
+Send a POST request to `http://localhost:8000/match` with the list of candidates and job postings you want to compare. Example payload:
+
+```json
+{
+  "candidates": [
+    {
+      "id": "cand-1",
+      "full_name": "Alex Dev",
+      "years_experience": 5,
+      "skills": ["Python", "FastAPI", "SQL"],
+      "desired_salary": 90000,
+      "preferred_locations": ["Berlin"],
+      "open_to_remote": true,
+      "industries": ["FinTech", "SaaS"]
+    }
+  ],
+  "jobs": [
+    {
+      "id": "job-1",
+      "title": "Backend Engineer",
+      "company": "Acme Corp",
+      "required_skills": ["Python", "FastAPI"],
+      "nice_to_have_skills": ["SQL"],
+      "minimum_years_experience": 4,
+      "salary_min": 85000,
+      "salary_max": 100000,
+      "location": "Berlin",
+      "remote_allowed": true,
+      "industries": ["FinTech"]
+    }
+  ],
+  "top_n": 3
+}
+```
+
+The response returns ranked jobs per candidate, including the score breakdown for transparency.
+
+### 4. Run tests
+
+```bash
+pytest
+```
+
+## Project Structure
+
+```
+app/               FastAPI application entrypoint
+src/hirex/         Reusable matching engine package
+└── engine.py      Core scoring heuristics
+└── models.py      Pydantic models shared by the engine and API
+tests/             Unit tests for the matching engine
+```
+
+## Extending the Engine
+
+- Adjust the default weights in `MatchingWeights` to change how individual factors contribute to the final score.
+- Replace the heuristic functions in `MatchingEngine` with embeddings or ML-based scoring if you want a more advanced AI approach.
+- Persist candidates and jobs in a database and feed them into the engine to create a full recruitment platform.
+
+## License
+
+This project is provided as-is without warranty. Adapt it to suit your hiring workflows.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,54 @@
+"""FastAPI application exposing the Hirex matching engine."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+
+from hirex.engine import MatchingEngine
+from hirex.models import CandidateMatches, CandidateProfile, JobPosting, MatchingWeights
+
+app = FastAPI(
+    title="Hirex Matching API",
+    description=(
+        "Suggest job matches for a collection of candidate profiles using "
+        "weighted heuristic scoring."
+    ),
+    version="0.1.0",
+)
+
+_default_engine = MatchingEngine()
+
+
+class MatchRequest(BaseModel):
+    candidates: List[CandidateProfile] = Field(..., description="Profiles to evaluate")
+    jobs: List[JobPosting] = Field(..., description="Job postings available for matching")
+    top_n: int = Field(3, ge=1, le=20, description="Maximum number of matches per candidate")
+    weights: Optional[MatchingWeights] = Field(
+        default=None, description="Override the default scoring weights"
+    )
+
+
+class MatchResponse(BaseModel):
+    weights: MatchingWeights
+    results: List[CandidateMatches]
+
+
+@app.get("/health", summary="Service health probe")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/match", response_model=MatchResponse, summary="Match candidates to jobs")
+async def match(request: MatchRequest) -> MatchResponse:
+    if request.weights is not None:
+        engine = MatchingEngine(request.weights)
+    else:
+        engine = _default_engine
+
+    results = engine.match_candidates_to_jobs(
+        request.candidates, request.jobs, top_n=request.top_n
+    )
+    return MatchResponse(weights=engine.weights, results=results)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = src

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.110.0
+uvicorn==0.29.0
+pydantic==2.6.4
+pytest==8.1.1

--- a/src/hirex/__init__.py
+++ b/src/hirex/__init__.py
@@ -1,0 +1,21 @@
+"""Hirex matching engine package."""
+
+from .engine import MatchingEngine
+from .models import (
+    CandidateMatches,
+    CandidateProfile,
+    JobMatch,
+    JobPosting,
+    MatchBreakdown,
+    MatchingWeights,
+)
+
+__all__ = [
+    "CandidateMatches",
+    "CandidateProfile",
+    "JobMatch",
+    "JobPosting",
+    "MatchBreakdown",
+    "MatchingEngine",
+    "MatchingWeights",
+]

--- a/src/hirex/engine.py
+++ b/src/hirex/engine.py
@@ -1,0 +1,190 @@
+"""Core matching logic for the Hirex platform."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+from .models import (
+    CandidateMatches,
+    CandidateProfile,
+    JobMatch,
+    JobPosting,
+    MatchBreakdown,
+    MatchingWeights,
+)
+
+
+@dataclass
+class ScoredMatch:
+    """Internal representation that couples a job with the score breakdown."""
+
+    job: JobPosting
+    score: float
+    breakdown: MatchBreakdown
+
+
+class MatchingEngine:
+    """Scores candidates against jobs using weighted heuristics."""
+
+    def __init__(self, weights: MatchingWeights | None = None) -> None:
+        self.weights = weights or MatchingWeights()
+
+    def match_candidates_to_jobs(
+        self,
+        candidates: Sequence[CandidateProfile],
+        jobs: Sequence[JobPosting],
+        *,
+        top_n: int = 3,
+    ) -> List[CandidateMatches]:
+        """Return the top job matches for each candidate.
+
+        Args:
+            candidates: Profiles of the job seekers to evaluate.
+            jobs: Available job postings to compare against.
+            top_n: Maximum number of matches to return per candidate.
+
+        Returns:
+            A list of :class:`CandidateMatches` with ranked job suggestions.
+        """
+
+        recommendations: List[CandidateMatches] = []
+        for candidate in candidates:
+            scored_jobs = [
+                self._score_candidate_for_job(candidate=candidate, job=job)
+                for job in jobs
+            ]
+            scored_jobs.sort(key=lambda match: match.score, reverse=True)
+            top_matches = [
+                JobMatch(job=match.job, score=match.score, breakdown=match.breakdown)
+                for match in scored_jobs[: max(0, top_n)]
+            ]
+            recommendations.append(CandidateMatches(candidate=candidate, matches=top_matches))
+        return recommendations
+
+    def _score_candidate_for_job(
+        self, candidate: CandidateProfile, job: JobPosting
+    ) -> ScoredMatch:
+        breakdown = MatchBreakdown(
+            skills=self._skill_score(candidate.skills, job.required_skills, job.nice_to_have_skills),
+            experience=self._experience_score(
+                candidate.years_experience, job.minimum_years_experience
+            ),
+            salary=self._salary_score(candidate.desired_salary, job.salary_min, job.salary_max),
+            location=self._location_score(
+                candidate.preferred_locations,
+                candidate.open_to_remote,
+                job.location,
+                job.remote_allowed,
+            ),
+            industry=self._industry_score(candidate.industries, job.industries),
+        )
+        score = breakdown.total(self.weights)
+        return ScoredMatch(job=job, score=round(score, 4), breakdown=breakdown)
+
+    def _skill_score(
+        self,
+        candidate_skills: Iterable[str],
+        required_skills: Iterable[str],
+        nice_to_have_skills: Iterable[str],
+    ) -> float:
+        cand_set = _normalized_set(candidate_skills)
+        required_set = _normalized_set(required_skills)
+        optional_set = _normalized_set(nice_to_have_skills)
+
+        if not cand_set and required_set:
+            return 0.0
+        if not required_set:
+            return 1.0 if cand_set else 0.5
+
+        matched_required = cand_set & required_set
+        base_score = len(matched_required) / len(required_set)
+
+        if optional_set:
+            matched_optional = cand_set & optional_set
+            optional_bonus = (len(matched_optional) / len(optional_set)) * 0.3
+        else:
+            optional_bonus = 0.0
+
+        return min(1.0, base_score + optional_bonus)
+
+    def _experience_score(
+        self, candidate_years: int, job_minimum_years: int
+    ) -> float:
+        if job_minimum_years <= 0:
+            return 1.0
+
+        if candidate_years >= job_minimum_years:
+            surplus = candidate_years - job_minimum_years
+            surplus_ratio = surplus / max(job_minimum_years, 1)
+            return min(1.0, 0.7 + min(surplus_ratio, 1.0) * 0.3)
+
+        deficit = job_minimum_years - candidate_years
+        penalty = deficit / (job_minimum_years + 1)
+        return max(0.0, 0.7 - penalty)
+
+    def _salary_score(
+        self,
+        desired_salary: int | None,
+        salary_min: int | None,
+        salary_max: int | None,
+    ) -> float:
+        if desired_salary is None or (salary_min is None and salary_max is None):
+            return 1.0
+
+        score = 1.0
+        if salary_max is not None and desired_salary > salary_max:
+            diff = desired_salary - salary_max
+            score -= min(1.0, diff / max(salary_max, 1))
+
+        if salary_min is not None and desired_salary < salary_min:
+            diff = salary_min - desired_salary
+            score -= min(0.4, diff / max(salary_min, 1) * 0.4)
+
+        return max(0.0, score)
+
+    def _location_score(
+        self,
+        preferred_locations: Iterable[str],
+        open_to_remote: bool,
+        job_location: str | None,
+        job_remote: bool,
+    ) -> float:
+        preferred = _normalized_set(preferred_locations)
+        job_loc = job_location.strip().lower() if job_location else None
+
+        if job_remote and open_to_remote:
+            return 1.0
+
+        if job_loc and job_loc in preferred:
+            return 1.0
+
+        if not preferred:
+            # Candidate is flexible; reward jobs that offer remote or specify a location
+            return 0.8 if job_loc else 1.0
+
+        # Candidate has preferences but this job does not match.
+        return 0.2 if job_loc else 0.4
+
+    def _industry_score(
+        self, candidate_industries: Iterable[str], job_industries: Iterable[str]
+    ) -> float:
+        candidate_set = _normalized_set(candidate_industries)
+        job_set = _normalized_set(job_industries)
+
+        if not candidate_set and not job_set:
+            return 0.5
+        if not candidate_set:
+            return 0.6
+        if not job_set:
+            return 0.7
+
+        intersection = candidate_set & job_set
+        return len(intersection) / len(job_set)
+
+
+def _normalized_set(values: Iterable[str]) -> set[str]:
+    return {value.strip().lower() for value in values if value and value.strip()}
+
+
+__all__ = ["MatchingEngine"]

--- a/src/hirex/models.py
+++ b/src/hirex/models.py
@@ -1,0 +1,158 @@
+"""Data models for the Hirex matching platform."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Field, validator
+
+
+class CandidateProfile(BaseModel):
+    """Represents a job seeker profile."""
+
+    id: str = Field(..., description="Unique identifier for the candidate")
+    full_name: str = Field(..., description="Display name for the candidate")
+    years_experience: int = Field(
+        ..., ge=0, description="Total number of professional experience years"
+    )
+    skills: List[str] = Field(
+        default_factory=list,
+        description="List of skills or technologies the candidate is comfortable with",
+    )
+    desired_salary: Optional[int] = Field(
+        default=None,
+        ge=0,
+        description="Annual salary expectation in the same unit as job postings",
+    )
+    preferred_locations: List[str] = Field(
+        default_factory=list,
+        description="Candidate preferred work locations (city, country, etc.)",
+    )
+    open_to_remote: bool = Field(
+        default=True, description="Whether the candidate is open to remote positions"
+    )
+    industries: List[str] = Field(
+        default_factory=list,
+        description="Industries the candidate has prior experience in",
+    )
+
+    @validator("skills", "preferred_locations", "industries", each_item=True)
+    def _strip_values(cls, value: str) -> str:
+        return value.strip()
+
+
+class JobPosting(BaseModel):
+    """Represents a job offer."""
+
+    id: str = Field(..., description="Unique identifier for the job")
+    title: str = Field(..., description="Title or name of the job role")
+    company: Optional[str] = Field(
+        default=None, description="Name of the company advertising the job"
+    )
+    required_skills: List[str] = Field(
+        default_factory=list,
+        description="Skills that are mandatory for the position",
+    )
+    nice_to_have_skills: List[str] = Field(
+        default_factory=list, description="Skills that are a bonus for the position"
+    )
+    minimum_years_experience: int = Field(
+        0,
+        ge=0,
+        description="Minimum experience expected for the role",
+    )
+    salary_min: Optional[int] = Field(
+        default=None,
+        ge=0,
+        description="Lower bound of the salary range for the position",
+    )
+    salary_max: Optional[int] = Field(
+        default=None,
+        ge=0,
+        description="Upper bound of the salary range for the position",
+    )
+    location: Optional[str] = Field(
+        default=None, description="Primary location where the job is based"
+    )
+    remote_allowed: bool = Field(
+        default=True, description="Whether the job supports remote work"
+    )
+    industries: List[str] = Field(
+        default_factory=list,
+        description="Industries associated with the job or company",
+    )
+
+    @validator("required_skills", "nice_to_have_skills", "industries")
+    def _strip_and_dedupe(cls, values: List[str]) -> List[str]:
+        seen: Dict[str, None] = {}
+        ordered_unique = []
+        for item in values:
+            normalized = item.strip()
+            if normalized and normalized.lower() not in seen:
+                ordered_unique.append(normalized)
+                seen[normalized.lower()] = None
+        return ordered_unique
+
+    @validator("salary_max")
+    def _ensure_salary_range(
+        cls, salary_max: Optional[int], values: Dict[str, Optional[int]]
+    ) -> Optional[int]:
+        salary_min = values.get("salary_min")
+        if salary_max is not None and salary_min is not None:
+            if salary_max < salary_min:
+                raise ValueError("salary_max cannot be lower than salary_min")
+        return salary_max
+
+
+class MatchBreakdown(BaseModel):
+    """Score decomposition used in responses."""
+
+    skills: float
+    experience: float
+    salary: float
+    location: float
+    industry: float
+
+    def total(self, weights: "MatchingWeights") -> float:
+        return (
+            self.skills * weights.skills
+            + self.experience * weights.experience
+            + self.salary * weights.salary
+            + self.location * weights.location
+            + self.industry * weights.industry
+        ) / weights.total_weight
+
+
+class JobMatch(BaseModel):
+    job: JobPosting
+    score: float
+    breakdown: MatchBreakdown
+
+
+class CandidateMatches(BaseModel):
+    candidate: CandidateProfile
+    matches: List[JobMatch]
+
+
+class MatchingWeights(BaseModel):
+    """Weights applied to each scoring component."""
+
+    skills: float = 0.45
+    experience: float = 0.2
+    salary: float = 0.15
+    location: float = 0.1
+    industry: float = 0.1
+
+    @property
+    def total_weight(self) -> float:
+        return self.skills + self.experience + self.salary + self.location + self.industry
+
+
+__all__ = [
+    "CandidateMatches",
+    "CandidateProfile",
+    "JobMatch",
+    "JobPosting",
+    "MatchBreakdown",
+    "MatchingWeights",
+]

--- a/tests/test_matching_engine.py
+++ b/tests/test_matching_engine.py
@@ -1,0 +1,97 @@
+"""Tests for the Hirex matching engine."""
+
+from __future__ import annotations
+
+from hirex.engine import MatchingEngine
+from hirex.models import CandidateProfile, JobPosting, MatchingWeights
+
+
+def _sample_candidate(**overrides):
+    data = dict(
+        id="cand-1",
+        full_name="Alex Dev",
+        years_experience=5,
+        skills=["Python", "FastAPI", "SQL"],
+        desired_salary=90000,
+        preferred_locations=["berlin"],
+        open_to_remote=True,
+        industries=["SaaS", "FinTech"],
+    )
+    data.update(overrides)
+    return CandidateProfile(**data)
+
+
+def _sample_job(**overrides):
+    data = dict(
+        id="job-1",
+        title="Backend Engineer",
+        company="Acme Corp",
+        required_skills=["Python", "FastAPI"],
+        nice_to_have_skills=["SQL"],
+        minimum_years_experience=4,
+        salary_min=85000,
+        salary_max=100000,
+        location="Berlin",
+        remote_allowed=True,
+        industries=["FinTech"],
+    )
+    data.update(overrides)
+    return JobPosting(**data)
+
+
+def test_full_match_scores_high() -> None:
+    candidate = _sample_candidate()
+    job = _sample_job()
+
+    engine = MatchingEngine()
+    matches = engine.match_candidates_to_jobs([candidate], [job], top_n=1)
+
+    assert matches[0].candidate.id == candidate.id
+    assert len(matches[0].matches) == 1
+
+    top_match = matches[0].matches[0]
+    assert top_match.job.id == job.id
+    assert top_match.breakdown.skills == 1.0
+    assert top_match.score >= 0.85
+
+
+def test_remote_mismatch_penalizes_location_score() -> None:
+    candidate = _sample_candidate(open_to_remote=False, preferred_locations=["Paris"])
+    job = _sample_job(location=None)
+
+    engine = MatchingEngine()
+    scored = engine.match_candidates_to_jobs([candidate], [job], top_n=1)[0].matches[0]
+
+    assert scored.breakdown.location < 0.5
+    assert scored.score < 0.8
+
+
+def test_better_skill_alignment_ranks_higher() -> None:
+    candidate = _sample_candidate(skills=["Python", "Django", "SQL", "Docker"])
+
+    close_match = _sample_job(id="job-close", required_skills=["Python", "Django"], nice_to_have_skills=["Docker"])
+    weak_match = _sample_job(
+        id="job-weak",
+        required_skills=["Go", "Kubernetes"],
+        nice_to_have_skills=["Rust"],
+    )
+
+    engine = MatchingEngine()
+    matches = engine.match_candidates_to_jobs([candidate], [close_match, weak_match], top_n=2)
+
+    job_ids = [match.job.id for match in matches[0].matches]
+    assert job_ids == ["job-close", "job-weak"]
+    assert matches[0].matches[0].score > matches[0].matches[1].score
+
+
+def test_custom_weights_modify_results() -> None:
+    candidate = _sample_candidate(skills=["Python"], desired_salary=120000)
+    job = _sample_job(required_skills=["Python"], salary_max=100000)
+
+    engine_default = MatchingEngine()
+    engine_salary_focus = MatchingEngine(MatchingWeights(skills=0.3, experience=0.1, salary=0.4, location=0.1, industry=0.1))
+
+    default_score = engine_default.match_candidates_to_jobs([candidate], [job])[0].matches[0].score
+    salary_weighted_score = engine_salary_focus.match_candidates_to_jobs([candidate], [job])[0].matches[0].score
+
+    assert salary_weighted_score < default_score


### PR DESCRIPTION
## Summary
- add Pydantic models for candidate profiles, job postings, and scoring weights
- implement a heuristic matching engine and expose it through a FastAPI endpoint
- provide project documentation, configuration, and unit tests covering the matching logic

## Testing
- pip install -r requirements.txt *(fails: proxy blocked outbound network)*
- pytest *(fails: missing dependency pydantic because installation step was blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68c88086e4f8832c94010588fa62a8ce