### PR TITLE
Add Procfile for API startup command

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: uvicorn app.main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Summary
- add a Procfile so Nixpacks will start the API with uvicorn

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c8915fbac8832ca1bc65270d596ada