### PR TITLE
Update Pydantic validators to field_validator signatures

### DIFF
--- a/src/hirex/models.py
+++ b/src/hirex/models.py
@@ -37,7 +37,9 @@ class CandidateProfile(BaseModel):
     )
 
     @field_validator("skills", "preferred_locations", "industries", mode="before")
-    def _strip_values(value: Optional[List[str]]) -> Optional[List[str]]:
+    def _strip_values(
+        cls, value: Optional[List[str]]
+    ) -> Optional[List[str]]:
         if value is None:
             return value
         if isinstance(value, list):
@@ -87,7 +89,9 @@ class JobPosting(BaseModel):
     )
 
     @field_validator("required_skills", "nice_to_have_skills", "industries", mode="before")
-    def _strip_and_dedupe(values: Optional[List[str]]) -> Optional[List[str]]:
+    def _strip_and_dedupe(
+        cls, values: Optional[List[str]]
+    ) -> Optional[List[str]]:
         if values is None:
             return None
         if not isinstance(values, list):
@@ -105,7 +109,7 @@ class JobPosting(BaseModel):
 
     @field_validator("salary_max")
     def _ensure_salary_range(
-        salary_max: Optional[int], info: ValidationInfo
+        cls, salary_max: Optional[int], info: ValidationInfo
     ) -> Optional[int]:
         salary_min = info.data.get("salary_min") if info.data else None
         if salary_max is not None and salary_min is not None:


### PR DESCRIPTION
## Summary
- update Hirex data models to use `field_validator` signatures compatible with Pydantic v2
- adjust candidate and job validators to accept the class parameter and keep preprocessing logic intact
- ensure salary range validator receives ValidationInfo while using the field validator decorator

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8a55d5d18832c983055fc40c947b0